### PR TITLE
Hl7 11 file validation

### DIFF
--- a/data/hl7-sample/test.json
+++ b/data/hl7-sample/test.json
@@ -1,0 +1,3 @@
+{
+    "hello": "hello"
+}

--- a/server/hl7/hl7.controller.js
+++ b/server/hl7/hl7.controller.js
@@ -8,19 +8,19 @@ const storage = multer.diskStorage({
   filename: (req, file, cb) => (cb(null, `${file.originalname}-${Date.now()}`))
 });
 
-const upload = multer({ storage ,
-  fileFilter: function(req, file, cb){
-    if(!file){
-      cb(new Error('No file found'),false);
+const upload = multer({ storage,
+  fileFilter(req, file, cb) {
+    if (!file) {
+      cb(new Error('No file found'), false);
     }
-    if(file.originalname.endsWith('.txt')){
-      cb(null,true)
-    }
-    else{
-      cb(new Error('File type not supported'), false)
+    if (file.originalname.endsWith('.txt')) {
+      cb(null, true);
+    } else {
+      cb(new Error('File type not supported'), false);
     }
   }
 });
+
 
 /**
  * Creates a new Mongoose object for the rile to save in the DB

--- a/server/hl7/hl7.controller.js
+++ b/server/hl7/hl7.controller.js
@@ -11,12 +11,12 @@ const storage = multer.diskStorage({
 const upload = multer({ storage,
   fileFilter(req, file, cb) {
     if (!file) {
-      cb(new Error('No file found', httpStatus.BAD_REQUEST), false); // TODO: Change to return 400 or something if no file found
+      cb(new APIError('No file found', httpStatus.BAD_REQUEST), false);
     }
     if (file.originalname.endsWith('.txt')) {
       cb(null, true);
     } else {
-      cb(new Error('File type not supported'), false); // TODO: Change to return 400 or something if wrong extensiom is given
+      cb(new APIError('File type not supported', httpStatus.BAD_REQUEST), false);
     }
   }
 });

--- a/server/hl7/hl7.controller.js
+++ b/server/hl7/hl7.controller.js
@@ -11,7 +11,7 @@ const storage = multer.diskStorage({
 const upload = multer({ storage,
   fileFilter(req, file, cb) {
     if (!file) {
-      cb(new Error('No file found'), false); //TODO: Change to return 400 or something if no file found
+      cb(new APIError('No file found', httpStatus.BAD_REQUEST), false);
     }
     if (file.originalname.endsWith('.txt')) {
       cb(null, true);

--- a/server/hl7/hl7.controller.js
+++ b/server/hl7/hl7.controller.js
@@ -11,12 +11,12 @@ const storage = multer.diskStorage({
 const upload = multer({ storage,
   fileFilter(req, file, cb) {
     if (!file) {
-      cb(new Error('No file found'), false);
+      cb(new Error('No file found'), false); //TODO: Change to return 400 or something if no file found
     }
     if (file.originalname.endsWith('.txt')) {
       cb(null, true);
     } else {
-      cb(new Error('File type not supported'), false);
+      cb(new Error('File type not supported'), false); //TODO: Change to return 400 or something if wrong extensiom is given
     }
   }
 });

--- a/server/hl7/hl7.controller.js
+++ b/server/hl7/hl7.controller.js
@@ -8,7 +8,19 @@ const storage = multer.diskStorage({
   filename: (req, file, cb) => (cb(null, `${file.originalname}-${Date.now()}`))
 });
 
-const upload = multer({ storage });
+const upload = multer({ storage ,
+  fileFilter: function(req, file, cb){
+    if(!file){
+      cb(new Error('No file found'),false);
+    }
+    if(file.originalname.endsWith('.txt')){
+      cb(null,true)
+    }
+    else{
+      cb(new Error('File type not supported'), false)
+    }
+  }
+});
 
 /**
  * Creates a new Mongoose object for the rile to save in the DB

--- a/server/hl7/hl7.controller.js
+++ b/server/hl7/hl7.controller.js
@@ -11,12 +11,12 @@ const storage = multer.diskStorage({
 const upload = multer({ storage,
   fileFilter(req, file, cb) {
     if (!file) {
-      cb(new Error('No file found'), false); //TODO: Change to return 400 or something if no file found
+      cb(new Error('No file found', httpStatus.BAD_REQUEST), false); // TODO: Change to return 400 or something if no file found
     }
     if (file.originalname.endsWith('.txt')) {
       cb(null, true);
     } else {
-      cb(new Error('File type not supported'), false); //TODO: Change to return 400 or something if wrong extensiom is given
+      cb(new Error('File type not supported'), false); // TODO: Change to return 400 or something if wrong extensiom is given
     }
   }
 });

--- a/server/hl7/hl7.test.js
+++ b/server/hl7/hl7.test.js
@@ -35,7 +35,7 @@ describe('## File Upload', () => {
       request(app)
         .post('/api/hl7/upload')
         .attach('hl7-message', 'data/hl7-sample/test.json')
-        .expect(httpStatus.INTERNAL_SERVER_ERROR) // TODO: You shouldn't be testing for a sever error here, test for 400
+        .expect(httpStatus.BAD_REQUEST) // TODO: You shouldn't be testing for a sever error here, test for 400
         .then(() => {
           done();
         })

--- a/server/hl7/hl7.test.js
+++ b/server/hl7/hl7.test.js
@@ -18,12 +18,24 @@ after((done) => {
 });
 
 describe('## File Upload', () => {
+
   describe('# POST /api/hl7/upload', () => {
     it('should upload a file to /data/hl7-uploads', (done) => {
       request(app)
         .post('/api/hl7/upload')
         .attach('hl7-message', 'data/hl7-sample/500HL7Messages.txt')
         .expect(httpStatus.CREATED)
+        .then(() => {
+          done();
+        })
+        .catch(done);
+    });
+
+    it('Should not upload a file that it not a .txt extension', (done) => {
+      request(app)
+        .post('/api/hl7/upload')
+        .attach('hl7-message', 'data/hl7-sample/test.json')
+        .expect(httpStatus.INTERNAL_SERVER_ERROR) // TODO: You shouldn't be testing for a sever error here, test for 400
         .then(() => {
           done();
         })

--- a/server/hl7/hl7.test.js
+++ b/server/hl7/hl7.test.js
@@ -18,7 +18,6 @@ after((done) => {
 });
 
 describe('## File Upload', () => {
-
   describe('# POST /api/hl7/upload', () => {
     it('should upload a file to /data/hl7-uploads', (done) => {
       request(app)
@@ -35,7 +34,7 @@ describe('## File Upload', () => {
       request(app)
         .post('/api/hl7/upload')
         .attach('hl7-message', 'data/hl7-sample/test.json')
-        .expect(httpStatus.INTERNAL_SERVER_ERROR) // TODO: You shouldn't be testing for a sever error here, test for 400
+        .expect(httpStatus.BAD_REQUEST)
         .then(() => {
           done();
         })


### PR DESCRIPTION
### Related JIRA tickets:
- https://jira.amida.com/browse/HL7-11

### What exactly does this PR do?
- validates that files must be a .txt file to be uploaded

### What else was added outside of the scope of the ask?
nothing 

### Do ANY of these changes introduce a breaking change? (in-scope or otherwise)
no

### Manual test cases?
- upload a txt file through postman to localhost:<your_port>/api/hl7/upload and you should receive a json object with filename, id, and date added 
- upload a non-txt file (.pdf for example) to localhost:<your_port>/api/hl7/upload and you should receive a json object with an "Internal Server Error" message with an "API Error" of "File type not supported" 


### Any additional context/background?
>N/A if this is straight-forward
- N/A

### Screenshots (if appropriate):
