### PR TITLE
added logic to retrieve all files uploaded by user

### DIFF
--- a/server/hl7/hl7.controller.js
+++ b/server/hl7/hl7.controller.js
@@ -83,4 +83,28 @@ function parseFile(req, res, next) {
   .catch(err => next(new APIError(err, httpStatus.INTERNAL_SERVER_ERROR)));
 }
 
-module.exports = { parseFile, upload };
+/**
+ * Get list of user files
+ * @returns {files[]}
+ */
+function getUserFiles(req, res) {
+  if (req.user && req.user.files.length > 0) {
+    const files = req.user.files.map((fileObj) => {
+      const fileName = fileObj.filename.split('/')[fileObj.filename.split('/').length - 1];
+      return fileName;
+    });
+    return res.status(httpStatus.OK).json(files);
+  }
+
+  let err;
+  if (req.user.files.length === 0) {
+    err = new APIError('User has no files uploaded', httpStatus.NO_CONTENT);
+  } else {
+    err = new APIError('There was an error retrieving uploaded files', httpStatus.BAD_REQUEST);
+  }
+
+  return res.status(httpStatus.BAD_REQUEST).json(err.message);
+}
+
+
+module.exports = { parseFile, upload, getUserFiles };

--- a/server/hl7/hl7.controller.js
+++ b/server/hl7/hl7.controller.js
@@ -87,11 +87,14 @@ function parseFile(req, res, next) {
  * Get list of user files
  * @returns {files[]}
  */
-function getUserFiles(req, res) {
+function getUserFiles(req, res, next) {
   if (req.user && req.user.files.length > 0) {
     const files = req.user.files.map((fileObj) => {
-      const fileName = fileObj.filename.split('/')[fileObj.filename.split('/').length - 1];
-      return fileName;
+      const file = {
+        id: fileObj._id,
+        name: fileObj.filename.split('/')[fileObj.filename.split('/').length - 1]
+      };
+      return file;
     });
     return res.status(httpStatus.OK).json(files);
   }
@@ -102,8 +105,7 @@ function getUserFiles(req, res) {
   } else {
     err = new APIError('There was an error retrieving uploaded files', httpStatus.BAD_REQUEST);
   }
-
-  return res.status(httpStatus.BAD_REQUEST).json(err.message);
+  return next(err);
 }
 
 

--- a/server/hl7/hl7.route.js
+++ b/server/hl7/hl7.route.js
@@ -9,4 +9,8 @@ router.route('/upload')
   /** POST /api/hl7/upload - Upload new HL7 document */
   .post(hl7Ctrl.upload.single('hl7-file'), hl7Ctrl.parseFile);
 
+router.route('/files')
+/** GET /api/hl7/files - Retrieves all user files */
+  .get(hl7Ctrl.getUserFiles);
+
 module.exports = router;

--- a/server/hl7/hl7.test.js
+++ b/server/hl7/hl7.test.js
@@ -101,7 +101,7 @@ describe('## Retrieve File', () => {
         .expect(httpStatus.OK)
         .then((res) => {
           expect(res.body.length).equal(1);
-          expect(res.body[0]).equal('500HL7Messages.txt');
+          expect(res.body[0].name).equal('500HL7Messages.txt');
           done();
         })
         .catch(done);

--- a/server/hl7/hl7.test.js
+++ b/server/hl7/hl7.test.js
@@ -2,6 +2,7 @@ const mongoose = require('mongoose');
 const request = require('supertest-as-promised');
 const httpStatus = require('http-status');
 const chai = require('chai'); // eslint-disable-line import/newline-after-import
+const expect = chai.expect;
 const app = require('../../index');
 
 chai.config.includeStack = true;
@@ -17,33 +18,34 @@ after((done) => {
   done();
 });
 
+const user = {
+  username: 'username',
+  email: 'mail@mail.mail',
+  password: 'Password1'
+};
+let userToken = '';
+before((done) => {
+  // create a user
+  request(app)
+    .post('/api/users')
+    .send(user)
+    .expect(httpStatus.OK)
+    // then sign in
+    .then(() => request(app)
+      .post('/api/users/login')
+      .send(user)
+      .expect(httpStatus.OK)
+      .then((res) => {
+        // save the token
+        userToken = res.body.token;
+        done();
+      })
+      .catch(done)
+    );
+});
+
 describe('## File Upload', () => {
   describe('# POST /api/hl7/upload', () => {
-    const user = {
-      username: 'username',
-      email: 'mail@mail.mail',
-      password: 'Password1'
-    };
-    let userToken = '';
-    before((done) => {
-      // create a user
-      request(app)
-        .post('/api/users')
-        .send(user)
-        .expect(httpStatus.OK)
-        // then sign in
-        .then(() => request(app)
-          .post('/api/users/login')
-          .send(user)
-          .expect(httpStatus.OK)
-          .then((res) => {
-            // save the token
-            userToken = res.body.token;
-            done();
-          })
-          .catch(done)
-        );
-    });
     it('should upload a file to /data/hl7-uploads', (done) => {
       request(app)
         .post('/api/hl7/upload')
@@ -83,6 +85,23 @@ describe('## File Upload', () => {
         .attach('hl7-file', 'server/tests/data/test.json')
         .expect(httpStatus.BAD_REQUEST)
         .then(() => {
+          done();
+        })
+        .catch(done);
+    });
+  });
+});
+
+describe('## Retrieve File', () => {
+  describe('# GET /api/hl7/files', () => {
+    it('should retrieve all the uploaded files ', (done) => {
+      request(app)
+        .get('/api/hl7/files')
+        .set('Authorization', `Bearer ${userToken}`)
+        .expect(httpStatus.OK)
+        .then((res) => {
+          expect(res.body.length).equal(1);
+          expect(res.body[0]).equal('500HL7Messages.txt');
           done();
         })
         .catch(done);

--- a/server/user/user.controller.js
+++ b/server/user/user.controller.js
@@ -49,7 +49,6 @@ function login(req, res, next) {
   });
 }
 
-
 /**
  * Create new user
  * @property {string} req.body.username - The username of user.
@@ -100,7 +99,6 @@ function create(req, res, next) {
     });
   });
 }
-
 
 /**
  * Update existing user

--- a/server/user/user.route.js
+++ b/server/user/user.route.js
@@ -25,7 +25,6 @@ router.route('/login')
 /** POST /api/users/login - Logs in existing user */
   .post(userCtrl.login);
 
-
 router.param('userId', userCtrl.load);
 
 module.exports = router;

--- a/yarn.lock
+++ b/yarn.lock
@@ -294,7 +294,7 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
-bcrypt@3.0.6:
+bcrypt@false3.0.6:
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/bcrypt/-/bcrypt-3.0.6.tgz#f607846df62d27e60d5e795612c4f67d70206eb2"
   integrity sha512-taA5bCTfXe7FUjKroKky9EXpdhkVvhE5owfxfLYodbrAR1Ul3juLmIQmIQBK4L9a5BuUcE6cqmwT+Da20lF9tg==


### PR DESCRIPTION
### Related JIRA tickets:
>Please enter the whole URL so we can just click/copy it
- https://jira.amida.com/browse/HL7-20

### What exactly does this PR do?
>i.e. Added logic to do the thing because the thing didn't exist before. Please provide as much detail as possible. 
- Adds endpoint to retrieve all the files uploaded by a user

### What else was added outside of the scope of the ask?
>i.e. Simple bugfix, corrected typos, cleaned up code, etc
- NA

### Do ANY of these changes introduce a breaking change? (in-scope or otherwise)
>i.e. Users need to update their `.env` files with the following... etc
- NO

### Manual test cases?
>Steps to manually test introduced changes can go here.
>Remember the prerequisites!
>Remember edge-cases you've caught in your code, etc..
> i.e. ignoring the button and clicking on the "NEXT" button should trigger a warning event because the thing that clicking the new button does didn't happen
- Upload a file or a couple (remember they have to be unique file names)
- then hit this endpoint `GET /api/hl7/files` you should get a list with all the file names a use has

### Any additional context/background?
>N/A if this is straight-forward
- Oddly I thought this this would be simple to do with a `/user/files` or something, but I ran into some issues when the user was being loaded to the request etc. Not sure if I was approaching it the right way or not, but doing it this way solved it. I'd love to hear if you know a much simpler route to have done this. 

### Screenshots (if appropriate):
