### PR TITLE
Hl7 23 po retrieve single message

### DIFF
--- a/server/hl7/hl7.route.js
+++ b/server/hl7/hl7.route.js
@@ -10,12 +10,18 @@ router.route('/upload')
   .post(hl7Ctrl.upload.single('hl7-file'), hl7Ctrl.parseFile);
 
 router.route('/files')
-/** GET /api/hl7/files - Retrieves all user files */
+  /** GET /api/hl7/files - Retrieves all user files */
   .get(hl7Ctrl.getUserFiles);
 
-router.route('/files/:fileId/messages/:indexWithinFileOrId')
-/** GET /api/hl7/files - Retrieves all user files */
-  .get(hl7Ctrl.getMessageByIndexOrId);
+router.route('/files/:fileId/messages/:indexWithinFile')
+  /** GET /api/hl7/files/fileId/messages/messageIndex -
+   * Retrieves single message from file based on index */
+  .get(hl7Ctrl.getMessageByIndex);
+
+router.route('/files/:fileId/messages/:messageId')
+  /** GET /api/hl7/files/fileId/messages/messageId -
+   * Retrieves single message from file based on ID */
+  .get(hl7Ctrl.getMessageByid);
 
 
 module.exports = router;

--- a/server/hl7/hl7.route.js
+++ b/server/hl7/hl7.route.js
@@ -13,4 +13,9 @@ router.route('/files')
 /** GET /api/hl7/files - Retrieves all user files */
   .get(hl7Ctrl.getUserFiles);
 
+router.route('/files/:fileId/messages/:indexWithinFileOrId')
+/** GET /api/hl7/files - Retrieves all user files */
+  .get(hl7Ctrl.getMessageByIndexOrId);
+
+
 module.exports = router;

--- a/server/hl7/hl7.test.js
+++ b/server/hl7/hl7.test.js
@@ -92,7 +92,7 @@ describe('## File Upload', () => {
   });
 });
 
-describe('## Retrieve File', () => {
+describe('## Retrieve File / Messages', () => {
   describe('# GET /api/hl7/files', () => {
     it('should retrieve all the uploaded files ', (done) => {
       request(app)
@@ -102,6 +102,24 @@ describe('## Retrieve File', () => {
         .then((res) => {
           expect(res.body.length).equal(1);
           expect(res.body[0].name).equal('500HL7Messages.txt');
+          done();
+        })
+        .catch(done);
+    });
+  });
+  describe('# GET /api/hl7/files/fileId/messages/messageIndex', () => {
+    it('should retrieve first message using message index ', (done) => {
+      request(app)
+        .get('/api/hl7/files')
+        .set('Authorization', `Bearer ${userToken}`)
+        .then((res) => {
+          request(app)
+            .get(`/api/hl7/files/${res.body[0].id}/messages/${0}`)
+            .set('Authorization', `Bearer ${userToken}`)
+            .expect(httpStatus.OK)
+            .then((response) => {
+              expect(response.body.messageNumWithinFile).equal(0);
+            });
           done();
         })
         .catch(done);


### PR DESCRIPTION
### Related JIRA tickets:
>Please enter the whole URL so we can just click/copy it
- https://jira.amida.com/browse/HL7-23

### What exactly does this PR do?
>i.e. Added logic to do the thing because the thing didn't exist before. Please provide as much detail as possible. 
- Added endpoint to return single Hl7 message from a given file (specified by the fileID + message index number or message Id)

### What else was added outside of the scope of the ask?
>i.e. Simple bugfix, corrected typos, cleaned up code, etc
- NA

### Do ANY of these changes introduce a breaking change? (in-scope or otherwise)
>i.e. Users need to update their `.env` files with the following... etc
- NA

### Manual test cases?
>Steps to manually test introduced changes can go here.
>Remember the prerequisites!
>Remember edge-cases you've caught in your code, etc..
> i.e. ignoring the button and clicking on the "NEXT" button should trigger a warning event because the thing that clicking the new button does didn't happen
- Post a file
- GET: http://localhost:4040/api/hl7/files/<fileId>/messages/<messageIndex or ID>
- NB: You may need the file ID as well as message id from mongo (to test with Postman). 
- Try it with values that don't exist.  

### Any additional context/background?
>N/A if this is straight-forward
- N/A

### Screenshots (if appropriate):
