### PR TITLE
Confirm file info on successful upload

### DIFF
--- a/server/hl7/hl7.controller.js
+++ b/server/hl7/hl7.controller.js
@@ -100,7 +100,7 @@ function getUserFiles(req, res, next) {
   if (req.user && req.user.files.length > 0) {
     const files = req.user.files.map((fileObj) => {
       const file = {
-        _id: fileObj._id,
+        id: fileObj._id,
         filename: getFileName(fileObj.filename)
       };
       return file;

--- a/server/hl7/hl7.controller.js
+++ b/server/hl7/hl7.controller.js
@@ -20,7 +20,7 @@ const storage = multer.diskStorage({
     // Check if file with the same name already exist in the FS.
     fs.stat(`${uploadedFilePath}/${file.originalname}`, (err) => {
       if (err === null) {
-        const error = new APIError('A file with that name already exist', httpStatus.CONFLICT);
+        const error = new APIError('A file with that name already exists', httpStatus.CONFLICT);
         cb(error, false);
       }
       cb(null, `${file.originalname}`);
@@ -80,7 +80,7 @@ function parseFile(req, res, next) {
       })
     ));
   })
-  .then(() => res.status(201).end())
+  .then(() => res.status(201).json(req.user.files[0]))
   .catch(err => next(new APIError(err, httpStatus.INTERNAL_SERVER_ERROR)));
 }
 

--- a/server/hl7/hl7.controller.js
+++ b/server/hl7/hl7.controller.js
@@ -41,6 +41,14 @@ const upload = multer({ storage,
   }
 });
 
+/**
+ * Helper function that returns file name from full path
+ * @param filepath
+ * @returns {string}
+ */
+function getFileName(filepath) {
+  return filepath.split('/')[filepath.split('/').length - 1];
+}
 
 /**
  * Takes in a raw hl7 message or a list of raw messages and returns a list of the parsed message
@@ -80,7 +88,7 @@ function parseFile(req, res, next) {
       })
     ));
   })
-  .then(() => res.status(201).json(req.user.files[0]))
+  .then(() => res.status(201).json(`Successfully uploaded ${getFileName(req.user.files[0].filename)}`))
   .catch(err => next(new APIError(err, httpStatus.INTERNAL_SERVER_ERROR)));
 }
 
@@ -92,8 +100,8 @@ function getUserFiles(req, res, next) {
   if (req.user && req.user.files.length > 0) {
     const files = req.user.files.map((fileObj) => {
       const file = {
-        id: fileObj._id,
-        name: fileObj.filename.split('/')[fileObj.filename.split('/').length - 1]
+        _id: fileObj._id,
+        filename: getFileName(fileObj.filename)
       };
       return file;
     });

--- a/server/hl7/hl7.controller.js
+++ b/server/hl7/hl7.controller.js
@@ -88,7 +88,7 @@ function parseFile(req, res, next) {
       })
     ));
   })
-  .then(() => res.status(201).json(`Successfully uploaded ${getFileName(req.user.files[0].filename)}`))
+  .then(() => res.status(201).send(`Successfully uploaded ${getFileName(req.user.files[0].filename)}`))
   .catch(err => next(new APIError(err, httpStatus.INTERNAL_SERVER_ERROR)));
 }
 

--- a/server/hl7/hl7.test.js
+++ b/server/hl7/hl7.test.js
@@ -101,7 +101,7 @@ describe('## Retrieve File / Messages', () => {
         .expect(httpStatus.OK)
         .then((res) => {
           expect(res.body.length).equal(1);
-          expect(res.body[0].name).equal('500HL7Messages.txt');
+          expect(res.body[0].filename).equal('500HL7Messages.txt');
           done();
         })
         .catch(done);


### PR DESCRIPTION
### Related JIRA tickets:
- [HL7-28](https://jira.amida.com/browse/HL7-28)

### What exactly does this PR do?
- Alters the response you get after uploading a file, now returns the file's name and ID

### What else was added outside of the scope of the ask?
- Tiny typo @ line 23

### Do ANY of these changes introduce a breaking change? (in-scope or otherwise)
- No

### Manual test cases?
- Login
- Hit the `/upload` endpoint and post a valid text file
- Confirm that the response is a JSON object containing ID and filename

### Any additional context/background?
- Note: linting errors are all indentation but look fine to me

### Screenshots (if appropriate):
- N/A
