### PR TITLE
add endpoint to retrieve a file

### DIFF
--- a/server/hl7/hl7.controller.js
+++ b/server/hl7/hl7.controller.js
@@ -125,7 +125,7 @@ function getFile(req, res, next) {
   const currentUser = req.user;
   const { fileId } = req.params
   const file = currentUser.files.find((f) => {
-    return f._id = fileId
+    return f._id == fileId
   })
 
   if (file) {

--- a/server/hl7/hl7.controller.js
+++ b/server/hl7/hl7.controller.js
@@ -127,7 +127,10 @@ function getFile(req, res, next) {
   const file = currentUser.files.find(f => f._id.toString() === fileId);
 
   if (file) {
-    return res.status(httpStatus.OK).json(file);
+    return res.status(httpStatus.OK).json({
+      id: file._id,
+      filename: getFileName(file.filename)
+    });
   }
   const err = new APIError('The requested file does not exist', httpStatus.NOT_FOUND);
   return next(err);

--- a/server/hl7/hl7.controller.js
+++ b/server/hl7/hl7.controller.js
@@ -124,9 +124,7 @@ function getUserFiles(req, res, next) {
 function getFile(req, res, next) {
   const currentUser = req.user;
   const { fileId } = req.params;
-  const file = currentUser.files.find((f) => {
-    return f._id.toString() === fileId;
-  });
+  const file = currentUser.files.find(f => f._id.toString() === fileId);
 
   if (file) {
     return res.status(httpStatus.OK).json(file);

--- a/server/hl7/hl7.controller.js
+++ b/server/hl7/hl7.controller.js
@@ -123,15 +123,15 @@ function getUserFiles(req, res, next) {
  */
 function getFile(req, res, next) {
   const currentUser = req.user;
-  const { fileId } = req.params
+  const { fileId } = req.params;
   const file = currentUser.files.find((f) => {
-    return f._id === fileId
-  })
+    return f._id.toString() === fileId;
+  });
 
   if (file) {
-    return res.status(httpStatus.OK).json(file)
+    return res.status(httpStatus.OK).json(file);
   }
-  const err = new APIError('The requested file does not exist', httpStatus.NO_CONTENT);
+  const err = new APIError('The requested file does not exist', httpStatus.NOT_FOUND);
   return next(err);
 }
 
@@ -205,6 +205,10 @@ function _getMessageByIdOrIndex(value, fileId) {
 }
 
 module.exports = {
-  parseFile, upload, getUserFiles, getMessageByIndex,
-  getMessageByid, getFile
+  parseFile,
+  upload,
+  getUserFiles,
+  getMessageByIndex,
+  getMessageByid,
+  getFile
 };

--- a/server/hl7/hl7.controller.js
+++ b/server/hl7/hl7.controller.js
@@ -125,7 +125,7 @@ function getFile(req, res, next) {
   const currentUser = req.user;
   const { fileId } = req.params
   const file = currentUser.files.find((f) => {
-    return f._id == fileId
+    return f._id === fileId
   })
 
   if (file) {

--- a/server/hl7/hl7.controller.js
+++ b/server/hl7/hl7.controller.js
@@ -117,6 +117,24 @@ function getUserFiles(req, res, next) {
   return next(err);
 }
 
+/**
+ * Get get a file given it's id
+ * @returns {file}
+ */
+function getFile(req, res, next) {
+  const currentUser = req.user;
+  const { fileId } = req.params
+  const file = currentUser.files.find((f) => {
+    return f._id = fileId
+  })
+
+  if (file) {
+    return res.status(httpStatus.OK).json(file)
+  }
+  const err = new APIError('The requested file does not exist', httpStatus.NO_CONTENT);
+  return next(err);
+}
+
 function getMessageByid(req, res, next) {
   let error;
   const messageId = req.params.messageId;
@@ -186,4 +204,7 @@ function _getMessageByIdOrIndex(value, fileId) {
   });
 }
 
-module.exports = { parseFile, upload, getUserFiles, getMessageByIndex, getMessageByid };
+module.exports = {
+  parseFile, upload, getUserFiles, getMessageByIndex,
+  getMessageByid, getFile
+};

--- a/server/hl7/hl7.route.js
+++ b/server/hl7/hl7.route.js
@@ -12,6 +12,10 @@ router.route('/upload')
 router.route('/files')
   /** GET /api/hl7/files - Retrieves all user files */
   .get(hl7Ctrl.getUserFiles);
+router.route('/files/:fileId')
+  /** GET /api/hl7/files/fileId -
+   * Retrieves single file given it's id */
+  .get(hl7Ctrl.getFile);
 
 router.route('/files/:fileId/messages/:indexWithinFile')
   /** GET /api/hl7/files/fileId/messages/messageIndex -

--- a/server/hl7/hl7.test.js
+++ b/server/hl7/hl7.test.js
@@ -94,7 +94,7 @@ describe('## File Upload', () => {
 
 describe('## Retrieve File / Messages', () => {
   describe('# GET /api/hl7/files', () => {
-    it('should retrieve all the uploaded files ', (done) => {
+    it('should retrieve all the uploaded files', (done) => {
       request(app)
         .get('/api/hl7/files')
         .set('Authorization', `Bearer ${userToken}`)
@@ -104,6 +104,29 @@ describe('## Retrieve File / Messages', () => {
           expect(res.body[0].filename).equal('500HL7Messages.txt');
           done();
         })
+        .catch(done);
+    });
+  });
+  describe('# GET /api/hl7/file/:fileId', () => {
+    it('should retrieve one file by its id', (done) => {
+      request(app)
+        .get('/api/hl7/files')
+        .set('Authorization', `Bearer ${userToken}`)
+        .expect(httpStatus.OK)
+        .then((res) => {
+          expect(res.body.length).equal(1);
+          const fileId = res.body[0].id;
+          const filename = res.body[0].filename;
+          return request(app)
+            .get(`/api/hl7/files/${fileId}`)
+            .set('Authorization', `Bearer ${userToken}`)
+            .expect(httpStatus.OK)
+            .then((res2) => {
+              expect(res2.body.id).to.equal(fileId);
+              expect(res2.body.filename).to.equal(filename);
+            });
+        })
+        .then(done)
         .catch(done);
     });
   });

--- a/server/hl7/hl7.test.js
+++ b/server/hl7/hl7.test.js
@@ -129,6 +129,14 @@ describe('## Retrieve File / Messages', () => {
         .then(done)
         .catch(done);
     });
+    it('should fail to retrieve nonexistent file', (done) => {
+      request(app)
+        .get('/api/hl7/files/doesntexist')
+        .set('Authorization', `Bearer ${userToken}`)
+        .expect(httpStatus.NOT_FOUND)
+        .then(() => done())
+        .catch(done);
+    });
   });
   describe('# GET /api/hl7/files/fileId/messages/messageIndex', () => {
     it('should retrieve first message using message index ', (done) => {


### PR DESCRIPTION
### Related JIRA tickets:
https://jira.amida.com/browse/HL7-37

### What exactly does this PR do?
When a user refreshed a page after navigating to a file page from the file list page, the file name at the top of the screen was lost. This PR allows us to retrieve the file from the back end when the page is loaded

### What else was added outside of the scope of the ask?
Nothing
### Do ANY of these changes introduce a breaking change? (in-scope or otherwise)
Not to my knowledge
### Manual test cases?
Simply navigate to a file detail page from the file list. Refresh the page and assert that the file name is rendered at the top of the screen