### PR TITLE
Hl7 38 file handling

### DIFF
--- a/server/hl7/hl7.controller.js
+++ b/server/hl7/hl7.controller.js
@@ -70,10 +70,8 @@ function parseFile(req, res, next) {
   }).catch(err =>
     next(new APIError(err, httpStatus.BAD_REQUEST))
   ).then((data) => {
-    if(!data.startsWith("MSH|")){
-      console.log("please upload a valid hl7 file");
-      throw new Error('Please upload an HL7 file');
-      return null;
+    if (!data.startsWith('MSH|')) {
+      throw new Error('Please upload a valid HL7 file');
     }
     req.user.files.unshift({ filename: req.file.path });
     const newFile = req.user.files[0];

--- a/server/hl7/hl7.controller.js
+++ b/server/hl7/hl7.controller.js
@@ -70,6 +70,11 @@ function parseFile(req, res, next) {
   }).catch(err =>
     next(new APIError(err, httpStatus.BAD_REQUEST))
   ).then((data) => {
+    if(!data.startsWith("MSH|")){
+      console.log("please upload a valid hl7 file");
+      throw new Error('Please upload an HL7 file');
+      return null;
+    }
     req.user.files.unshift({ filename: req.file.path });
     const newFile = req.user.files[0];
     return Promise.all([data, newFile, req.user.save()]);
@@ -91,7 +96,6 @@ function parseFile(req, res, next) {
   .then(() => res.status(201).send(`Successfully uploaded ${getFileName(req.user.files[0].filename)}`))
   .catch(err => next(new APIError(err, httpStatus.INTERNAL_SERVER_ERROR)));
 }
-
 /**
  * Get list of user files
  * @returns {files[]}


### PR DESCRIPTION
### Related JIRA tickets:
>Please enter the whole URL so we can just click/copy it
-https://jira.amida.com/projects/HL7/issues/HL7-38

### What exactly does this PR do?
>i.e. Added logic to do the thing because the thing didn't exist before. Please provide as much detail as possible. 
- adding the ability to verify that a uploaded text file is an hl7 file by asserting that it starts with a message header (MSH|)

### What else was added outside of the scope of the ask?
>i.e. Simple bugfix, corrected typos, cleaned up code, etc
-

### Do ANY of these changes introduce a breaking change? (in-scope or otherwise)
>i.e. Users need to update their `.env` files with the following... etc
-

### Manual test cases?
>Steps to manually test introduced changes can go here.
>Remember the prerequisites!
>Remember edge-cases you've caught in your code, etc..
> i.e. ignoring the button and clicking on the "NEXT" button should trigger a warning event because the thing that clicking the new button does didn't happen
- run yarn start
- upload a text file that does not start with "MSH|" on postman
- assert that the returned error reads "Please upload a valid HL7 file"

### Any additional context/background?
>N/A if this is straight-forward
- N/A

### Screenshots (if appropriate):
