### PR TITLE
Feature/test env

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,7 @@
+NODE_ENV=test
+PORT=4040
+MONGO_HOST=mongodb://localhost/hl7-telescoper-api-server-development
+MONGO_PORT=27017
+JWT_SECRET=0a6b944d-d2fb-46fc-a85e-0295c986cd9f
+JWT_EXP_TIME=1h
+FILE_UPLOAD_PATH=data/hl7-uploads-test

--- a/config/config.js
+++ b/config/config.js
@@ -1,5 +1,14 @@
 const Joi = require('joi');
+const dotenv = require('dotenv')
 
+// require and configure dotenv, will load vars in .env or .env.test in PROCESS.ENV
+if (process.env.NODE_ENV === 'test') {
+  console.log('config.js: Using .env.test')
+  dotenv.config({ path: '.env.test' });
+} else {
+  console.log('config.js: Using .env')
+  dotenv.config();
+}
 // require and configure dotenv, will load vars in .env in PROCESS.ENV
 require('dotenv').config();
 

--- a/server/hl7/hl7.test.js
+++ b/server/hl7/hl7.test.js
@@ -31,6 +31,10 @@ const user = {
 };
 let userToken = '';
 before((done) => {
+  if(!fs.existsSync('data/hl7-uploads-test')) {
+    fs.mkdirSync('data/hl7-uploads-test')
+  }
+
   // create a user
   request(app)
     .post('/api/users')

--- a/server/hl7/hl7.test.js
+++ b/server/hl7/hl7.test.js
@@ -4,6 +4,7 @@ const httpStatus = require('http-status');
 const chai = require('chai'); // eslint-disable-line import/newline-after-import
 const expect = chai.expect;
 const app = require('../../index');
+const fs = require('fs');
 
 chai.config.includeStack = true;
 
@@ -11,6 +12,11 @@ chai.config.includeStack = true;
  * root level hooks
  */
 after((done) => {
+  // Deleting any sample HL7 message used for testing if they exist already before running tests
+  fs.unlinkSync('data/hl7-uploads-test/500HL7Messages.txt', (err) => {
+    if (err) throw err;
+    console.log('data/hl7-uploads-test/500HL7Messages.txt was deleted');
+  });
   // required because https://github.com/Automattic/mongoose/issues/1251#issuecomment-65793092
   mongoose.models = {};
   mongoose.modelSchemas = {};
@@ -46,7 +52,7 @@ before((done) => {
 
 describe('## File Upload', () => {
   describe('# POST /api/hl7/upload', () => {
-    it('should upload a file to /data/hl7-uploads', (done) => {
+    it('should upload a file to /data/hl7-uploads-test', (done) => {
       request(app)
         .post('/api/hl7/upload')
         .set('Authorization', `Bearer ${userToken}`)

--- a/yarn.lock
+++ b/yarn.lock
@@ -294,7 +294,7 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
-bcrypt@false3.0.6:
+bcrypt@3.0.6:
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/bcrypt/-/bcrypt-3.0.6.tgz#f607846df62d27e60d5e795612c4f67d70206eb2"
   integrity sha512-taA5bCTfXe7FUjKroKky9EXpdhkVvhE5owfxfLYodbrAR1Ul3juLmIQmIQBK4L9a5BuUcE6cqmwT+Da20lF9tg==


### PR DESCRIPTION
### Related JIRA tickets:
>Please enter the whole URL so we can just click/copy it
- https://jira.amida.com/browse/HL7-40
- https://jira.amida.com/browse/HL7-33
### What exactly does this PR do?
>i.e. Added logic to do the thing because the thing didn't exist before. Please provide as much detail as possible. 
- This PR create and incorporates a `.env.test` for running the tests instead of using the same `.env` used for development purposes. In addition, a directory `hl7-uploads-test` is created to temporary stores the `500HL7Messages.txt` produced by the tests.
- Removes the `500HL7Messages.txt` created after running the `yarn test`. This allows you to run the tests over and over again. Before, you had to manually delete `500HL7Messages.txt` in order to pass all tests. If you ran the tests with `500HL7Messages.txt` still in `data/hl7-uploads`, some tests would fail.

### Do ANY of these changes introduce a breaking change? (in-scope or otherwise)
>i.e. Users need to update their `.env` files with the following... etc
- No.

### Manual test cases?
>Steps to manually test introduced changes can go here.
>Remember the prerequisites!
>Remember edge-cases you've caught in your code, etc..
> i.e. ignoring the button and clicking on the "NEXT" button should trigger a warning event because the thing that clicking the new button does didn't happen

**Case 1**
- Checkout branch
- run server and db
- run `yarn test`
- At the beginning of the output of the test, ensure the the following text appears: `config.js: Using .env.test`
- This means that tests are using the `.env.test` env file and not the `.env` for development
After running `yarn test`, ensure that you have the following directory: `data/hl7-uploads-test/` and that it's empty, meaning it doesn't have the file `500HL7Messages.txt` in it.
- You can run `yarn test` more than once without failing any tests. This is something we couldn't do before this PR.

**Case 2**
- Now run `yarn start`
- At the beginning of the output, you should see the text `config.js: Using .env`


